### PR TITLE
fix(docs): add allow_inspection: false for GitHub Pages build

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ plugins:
           options:
             show_root_heading: true
             show_source: true
+            allow_inspection: false
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Set `allow_inspection: false` on the mkdocstrings python handler so it uses static source analysis instead of runtime imports. This fixes the GitHub Pages build which fails because the genesis module cannot be imported in CI without installing all project dependencies.