### PR TITLE
fix(ci): update deploy.yml paths for lib/ monorepo layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [main]
     paths:
-      - 'genesis_rust_backend/**'
-      - 'genesis/webui/frontend/**'
+      - 'lib/rust/genesis_rust_backend/**'
+      - 'lib/python/genesis/webui/frontend/**'
       - 'migrations/**'
       - 'terraform/**'
       - '.github/workflows/deploy.yml'
@@ -34,10 +34,10 @@ jobs:
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push
-        working-directory: genesis_rust_backend
+        working-directory: lib/rust
         run: |
           IMAGE="${{ env.REGISTRY }}/backend:${{ github.sha }}"
-          docker build -t "${IMAGE}" -t "${{ env.REGISTRY }}/backend:latest" .
+          docker build -f genesis_rust_backend/Dockerfile -t "${IMAGE}" -t "${{ env.REGISTRY }}/backend:latest" .
           docker push "${IMAGE}"
           docker push "${{ env.REGISTRY }}/backend:latest"
 
@@ -58,7 +58,7 @@ jobs:
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
 
       - name: Build and push
-        working-directory: genesis/webui/frontend
+        working-directory: lib/python/genesis/webui/frontend
         run: |
           IMAGE="${{ env.REGISTRY }}/frontend:${{ github.sha }}"
           docker build -t "${IMAGE}" -t "${{ env.REGISTRY }}/frontend:latest" .

--- a/lib/rust/genesis_rust_backend/Dockerfile
+++ b/lib/rust/genesis_rust_backend/Dockerfile
@@ -3,11 +3,11 @@ FROM rust:1.83-bookworm AS builder
 WORKDIR /app
 
 # Cache dependencies by building a dummy project first
-COPY Cargo.toml Cargo.lock ./
+COPY genesis_rust_backend/Cargo.toml Cargo.lock ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src
 
 # Build real application
-COPY src ./src
+COPY genesis_rust_backend/src ./src
 RUN touch src/main.rs && cargo build --release
 
 FROM gcr.io/distroless/cc-debian12


### PR DESCRIPTION
## Problem

The deploy workflow still references the pre-restructure directory layout:
- Path triggers: `genesis_rust_backend/**` and `genesis/webui/frontend/**`
- Working directories: `genesis_rust_backend` and `genesis/webui/frontend`

This means the deploy workflow **never triggers** on actual code changes, and if triggered manually, Docker builds fail because the directories don't exist.

## Fix

- Updated path triggers to `lib/rust/genesis_rust_backend/**` and `lib/python/genesis/webui/frontend/**`
- Updated backend build working directory to `lib/rust` with `-f genesis_rust_backend/Dockerfile`
- Updated frontend build working directory to `lib/python/genesis/webui/frontend`
- Updated backend Dockerfile COPY paths to work with `lib/rust/` as the build context (since `Cargo.lock` lives at the workspace level)