### PR TITLE
fix(docker): correct build context and Dockerfile paths for monorepo layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 
 FROM rust:1.83-bookworm AS builder
 WORKDIR /app
-COPY lib/rust/Cargo.toml lib/rust/Cargo.lock ./
+COPY lib/rust/genesis_rust_backend/Cargo.toml lib/rust/Cargo.lock ./
 RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src
-COPY lib/rust/src ./src
+COPY lib/rust/genesis_rust_backend/src ./src
 RUN touch src/main.rs && cargo build --release
 
 FROM gcr.io/distroless/cc-debian12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
   backend:
     build:
       context: lib/rust
-      dockerfile: Dockerfile
+      dockerfile: genesis_rust_backend/Dockerfile
     container_name: genesis-backend
     environment:
       DATABASE_URL: postgresql://genesis_app:${POSTGRES_PASSWORD:-genesis_dev}@postgres:5432/genesis


### PR DESCRIPTION
## Problem

1. **docker-compose.yml**: Backend service references `dockerfile: Dockerfile` relative to `context: lib/rust`, but no `Dockerfile` exists at `lib/rust/Dockerfile`. The actual file is at `lib/rust/genesis_rust_backend/Dockerfile`.

2. **Root Dockerfile**: Copies the workspace `Cargo.toml` (which has `[workspace] members = [...]` and no binary target) and a nonexistent `lib/rust/src/` directory.

## Fix

- `docker-compose.yml`: Changed `dockerfile: Dockerfile` → `dockerfile: genesis_rust_backend/Dockerfile`
- Root `Dockerfile`: Changed COPY paths to use `lib/rust/genesis_rust_backend/Cargo.toml` and `lib/rust/genesis_rust_backend/src`