### PR TITLE
fix(frontend): handle UUID-based run IDs in database selector

### DIFF
--- a/lib/python/genesis/webui/frontend/src/components/CommandMenu.tsx
+++ b/lib/python/genesis/webui/frontend/src/components/CommandMenu.tsx
@@ -151,10 +151,8 @@ export default function CommandMenu() {
 
         <CommandGroup heading="Databases">
           {state.databases.map((db) => {
-             // Create a readable label
-             const parts = db.path.split('/');
-             const task = parts.length >= 3 ? parts[parts.length - 3] : 'Unknown';
-             const name = parts.length >= 2 ? parts[parts.length - 2] : 'Unknown';
+             const task = db.task_name || 'Unknown';
+             const name = db.name || 'Unknown';
              return (
                <CommandItem
                  key={db.path}

--- a/lib/python/genesis/webui/frontend/src/components/DatabaseSelector.tsx
+++ b/lib/python/genesis/webui/frontend/src/components/DatabaseSelector.tsx
@@ -13,18 +13,15 @@ export default function DatabaseSelector() {
   const { tasksAndResults, currentDbPath, isLoading, autoRefreshEnabled } =
     state;
 
-  // Extract current task and result from path
+  // Extract current task and result from state
   const { currentTask, currentResult } = useMemo(() => {
     if (!currentDbPath) return { currentTask: '', currentResult: '' };
-    const parts = currentDbPath.split('/');
-    if (parts.length >= 3) {
-      return {
-        currentTask: parts[parts.length - 3],
-        currentResult: currentDbPath,
-      };
-    }
-    return { currentTask: '', currentResult: '' };
-  }, [currentDbPath]);
+    const db = state.databases.find(d => d.path === currentDbPath);
+    return {
+      currentTask: db?.task_name || '',
+      currentResult: currentDbPath,
+    };
+  }, [currentDbPath, state.databases]);
 
   // Load databases on mount
   useEffect(() => {

--- a/lib/python/genesis/webui/frontend/src/context/GenesisContext.tsx
+++ b/lib/python/genesis/webui/frontend/src/context/GenesisContext.tsx
@@ -84,31 +84,21 @@ function reducer(state: AppState, action: Action): AppState {
 // Helper to organize databases by task
 function organizeDatabases(dbs: DatabaseInfo[]): TasksAndResults {
   const tasksAndResults: TasksAndResults = {};
-
   dbs.forEach((db) => {
-    const pathParts = db.path.split('/');
-    if (pathParts.length >= 3) {
-      const task = pathParts[pathParts.length - 3];
-      const result = pathParts[pathParts.length - 2];
-
-      if (!tasksAndResults[task]) {
-        tasksAndResults[task] = [];
-      }
-
-      tasksAndResults[task].push({
-        name: result,
-        path: db.path,
-        sortKey: db.sort_key || '0',
-        stats: db.stats,
-      });
+    const task = db.task_name || 'Unknown';
+    if (!tasksAndResults[task]) {
+      tasksAndResults[task] = [];
     }
+    tasksAndResults[task].push({
+      name: db.name,
+      path: db.path,
+      sortKey: db.sort_key || '0',
+      stats: db.stats,
+    });
   });
-
-  // Sort results within each task by date (newest first)
   Object.keys(tasksAndResults).forEach((task) => {
     tasksAndResults[task].sort((a, b) => b.sortKey.localeCompare(a.sortKey));
   });
-
   return tasksAndResults;
 }
 

--- a/lib/python/genesis/webui/frontend/src/services/api.ts
+++ b/lib/python/genesis/webui/frontend/src/services/api.ts
@@ -19,6 +19,7 @@ export async function listDatabases(): Promise<DatabaseInfo[]> {
     }) => ({
       path: r.run_id,
       name: `${r.task_name} (${r.status})`,
+      task_name: r.task_name,
       sort_key: r.start_time,
       stats: {
         total: r.population_size,

--- a/lib/python/genesis/webui/frontend/src/types/index.ts
+++ b/lib/python/genesis/webui/frontend/src/types/index.ts
@@ -49,6 +49,7 @@ export interface LLMResult {
 export interface DatabaseInfo {
   path: string;
   name: string;
+  task_name?: string;
   actual_path?: string;
   sort_key?: string;
   stats?: {


### PR DESCRIPTION
## Problem

The Rust backend returns UUID strings as `run_id`, but three frontend components assumed file-system-like paths and split on `/`:

1. **`organizeDatabases()`** in `GenesisContext.tsx` — splits `db.path` on `/` expecting `>=3` segments. UUIDs have no slashes, so `pathParts.length` is always 1 and every database is silently dropped. The sidebar is always empty.

2. **`DatabaseSelector.tsx`** — same path-splitting pattern for `currentTask` derivation.

3. **`CommandMenu.tsx`** — same pattern for display labels.

## Fix

- Added `task_name` field to `DatabaseInfo` type and populated it from the API response (`r.task_name`)
- Replaced all `path.split('/')` logic with direct `db.task_name` / `db.name` field access
- Databases are now correctly grouped by task name and rendered in the sidebar